### PR TITLE
ci: enable Renovate for forked repo

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,9 @@
     "config:recommended"
   ],
 
+  // This repo is a fork of skolobov/mkrel - enable Renovate processing
+  "forkProcessing": "enabled",
+
   // Target develop branch for dependency updates
   "baseBranches": [
     "develop"


### PR DESCRIPTION
This repo is a fork of skolobov/mkrel, so Renovate skips it by default.

Add `forkProcessing: enabled` to allow dependency updates.

## Reference
- Renovate log showed: `Repository is a fork and not manually configured - skipping`