### PR TITLE
fix(ci): use gh CLI instead of MCP tools for PR reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,17 +27,13 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request with a focus on:
+            Review this pull request focusing on:
             - Code quality and best practices
             - Potential bugs or issues
             - Security implications
             - Performance considerations
 
-            Note: The PR branch is already checked out in the current working directory.
-
-            Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
-
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            The PR branch is checked out in the current directory.
+            Use `gh pr diff` to see changes and `gh pr view` for details.
+            Post your review using `gh pr comment` for feedback.
+            Do not output review text as messages - only post via gh commands.


### PR DESCRIPTION
## Summary
- Remove MCP tool references (`mcp__github_inline_comment__create_inline_comment`)
- Use `gh` CLI commands which work reliably without additional setup
- Simplify prompt to focus on gh-based workflow

## Why
The MCP tools require GitHub App MCP server initialization, which is affected by
an upstream bug (anthropics/claude-code-action#723). The `gh` CLI provides the
same functionality and works out of the box.

## Test plan
- [ ] Verify workflow runs successfully on a PR
- [ ] Confirm Claude posts review comments via `gh pr comment`