### PR TITLE
fix(ci): add missing permissions and allowed-tools for PR reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
   id-token: write
 
 jobs:
@@ -37,3 +38,5 @@ jobs:
             Use `gh pr diff` to see changes and `gh pr view` for details.
             Post your review using `gh pr comment` for feedback.
             Do not output review text as messages - only post via gh commands.
+
+          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary
- Add `issues: write` permission required for gh commands
- Add `claude_args` with `--allowed-tools` to explicitly enable Bash gh commands

## Why
Without `--allowed-tools`, Claude cannot execute `gh pr comment` to post reviews.
The permission was also missing compared to a working reference implementation.

## Test plan
- [ ] Verify Claude PR Review workflow posts a comment on this PR