### PR TITLE
chore: switch Homebrew from cask to formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,8 +54,8 @@ changelog:
       - "^chore:"
       - "^ci:"
 
-# Homebrew cask configuration (replaces deprecated brews)
-homebrew_casks:
+# Homebrew formula for CLI tool distribution
+brews:
   - repository:
       owner: kloudlabs-io
       name: homebrew-tap
@@ -66,6 +66,8 @@ homebrew_casks:
     homepage: "https://github.com/kloudlabs-io/mkrel"
     description: "Release management tool with Git Flow and CalVer/SemVer support"
     license: "MIT"
+    install: |
+      bin.install "mkrel"
 
 release:
   github:


### PR DESCRIPTION
## Summary
- Switch from `homebrew_casks` to `brews` in GoReleaser config

Formulas are the standard distribution method for CLI tools. Casks are intended for macOS GUI apps (.app bundles).

Closes #28

## Test plan
- [ ] Next release creates a formula in homebrew-tap (not a cask)
- [ ] `brew install kloudlabs-io/tap/mkrel` still works